### PR TITLE
Add Korean Alphabet(Hangul) and Vietnamese Pronunciation.

### DIFF
--- a/src/kcharselect.cpp
+++ b/src/kcharselect.cpp
@@ -1,6 +1,7 @@
 /* This file is part of the KDE libraries
 
    Copyright (C) 1999 Reginald Stadlbauer <reggie@kde.org>
+   Copyright (c) 2016 DaeHyun Sung  <sungdh86@gmail.com>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public
@@ -819,7 +820,7 @@ void KCharSelect::KCharSelectPrivate::_k_slotUpdateUnicode(uint c)
     }
 
     QStringList unihan = s_data()->unihanInfo(c);
-    if (unihan.count() == 7) {
+    if (unihan.count() == 9) {
         html += QStringLiteral("<p><b>") + tr("CJK Ideograph Information") + QStringLiteral("</b></p><p>");
         bool newline = true;
         if (!unihan[0].isEmpty()) {
@@ -868,6 +869,22 @@ void KCharSelect::KCharSelectPrivate::_k_slotUpdateUnicode(uint c)
             html += tr("Korean Pronunciation: ") + unihan[4];
             newline = false;
         }
+        if (!unihan[7].isEmpty()) {
+            if (!newline) {
+                html += QStringLiteral("<br>");
+            }
+            html += QStringLiteral("Korean Alphabet(Hangul): ") + unihan[7];
+            newline = false;
+        }
+        if (!unihan[8].isEmpty()) {
+            if (!newline) {
+                html += QStringLiteral("<br>");
+            }
+            html += QStringLiteral("Vietnamese Pronunciation: ") + unihan[8];
+            newline = false;
+        }
+
+
         html += QStringLiteral("</p>");
     }
 

--- a/src/kcharselectdata.cpp
+++ b/src/kcharselectdata.cpp
@@ -1,6 +1,7 @@
 /* This file is part of the KDE libraries
 
    Copyright (C) 2007 Daniel Laidig <d.laidig@gmx.de>
+   Copyright (c) 2016 DaeHyun Sung  <sungdh86@gmail.com>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public
@@ -606,19 +607,19 @@ QStringList KCharSelectData::unihanInfo(uint c)
 
     int min = 0;
     int mid;
-    int max = ((offsetEnd - offsetBegin) / 30) - 1;
+    int max = ((offsetEnd - offsetBegin) / 38) - 1;
 
     while (max >= min) {
         mid = (min + max) / 2;
-        const quint16 midUnicode = qFromLittleEndian<quint16>(udata + offsetBegin + mid * 30);
+        const quint16 midUnicode = qFromLittleEndian<quint16>(udata + offsetBegin + mid * 38);
         if (unicode > midUnicode) {
             min = mid + 1;
         } else if (unicode < midUnicode) {
             max = mid - 1;
         } else {
             QStringList res;
-            for (int i = 0; i < 7; i++) {
-                quint32 offset = qFromLittleEndian<quint32>(udata + offsetBegin + mid * 30 + 2 + i * 4);
+            for (int i = 0; i < 9; i++) {
+                quint32 offset = qFromLittleEndian<quint32>(udata + offsetBegin + mid * 38 + 2 + i * 4);
                 if (offset != 0) {
                     res.append(QString::fromUtf8(data + offset));
                 } else {


### PR DESCRIPTION
Add Korean Alphabet(Hangul) and Vietnamese Pronunciation.

Unihan_Readings.txt included in Unihan.zip defines the notation and pronunciation of East Asian languages such as Chinese, Japanese, Korean, Vietnamese.
Unihan_Readings.txt’ has some properties.
Such as 
kCantonese, kDefinition, kHangul, kHanyuPinlu, kHanyuPinyin, kJapaneseKun, kJapaneseOn, kKorean, kMandarin, kTang, kVietnamese, kXHC1983.

I add Unihan_Readings.txt defined kVietnamese property and kHangul property in this program.

Unihan_Readings.txt’s property kVietnamese describe Vietnamese character(Quốc ngữ) pronunciation. this property defined Unihan version 3.1.1. Now Unihan database version is 9.0.0.
Unihan_Readings.txt’s property kHangul describe Korean character(한글,Hangul) describe Korean pronunciation for this character in hangul.(Hangul is Korean Alphabet) this property defined Unihan version 5.0. Now Unihan database version is 9.0.0.
1. Why do I add kHangul(Korean Alphabet[Hangul]) property?
   Because, Unicode Consortium presented kHangul property on Unihan version 5.
   Unicode Unihan database document ( http://www.unicode.org/reports/tr38/  ) describe “kKorean” property.
   “kKorean property’s description” 
   The Korean pronunciation(s) of this character, using the Yale romanization system. (See http://en.wikipedia.org/wiki/Korean_romanization for a discussion of the various Korean romanization systems.)
   Use of the kKorean field is not recommended. The kHangul field, which is aligned to the KS X 1001 and KS X 1002 standards, is recommended to be used instead.

Now, Revised Romanization of Korean (RR, also called South Korean or Ministry of Culture (MC) 2000)  is the most commonly used and widely accepted system of romanization for Korean instead of "Yale romanization system"[kKorean property] in Unihan database.

So,  I add kHangul property and add “Korean Alphabet(Hangul)” notation.
1. Why do i add kVietnamese(Vietnamese pronunciation[Quốc ngữ]) property?
   “Unicode Consortium’s version9 guide chapter18. East Asia shows these paragraph.
   In Vietnam, a set of native ideographs was created for Vietnamese based on the same principles used to create new ideographs for Chinese. These Vietnamese ideographs were used through the beginning of the 20th century and are occasionally used in more recent signage and other limited contexts.

Although the term “CJK”—Chinese, Japanese, and Korean—is used throughout this text to describe the languages that currently use Han ideographic characters, it should be noted that earlier Vietnamese writing systems were based on Han ideographs. Consequently, the term “CJKV” would be more accurate in a historical sense. Han ideographs are still used for historical, religious, and pedagogical purposes in Vietnam. “

So I read Unihan documentation specification, then  support Vietnamese language.
